### PR TITLE
Do not control the behaviour with assert statement

### DIFF
--- a/http_repo/app.py
+++ b/http_repo/app.py
@@ -57,10 +57,8 @@ async def handle_post(req):
 
 
 if __name__ == '__main__':
-    try:
-        files_path = os.getenv('FILES_ROOT')
-        assert files_path is not None
-    except AssertionError:
+    files_path = os.getenv('FILES_ROOT')
+    if files_path is None:
         print('USAGE: python3 ./http_repo/app.py')
         print('Required envs: FILES_ROOT')
         exit(1)


### PR DESCRIPTION
According to the Python [documentation](https://docs.python.org/3/reference/simple_stmts.html#the-assert-statement)
> The current code generator emits no code for an assert statement when optimization is requested at compile time.

This means, if ran with -O option, assert statement will be stripped out from the code and the program might change its behavious by not checking the file path properly.